### PR TITLE
Pyportal flash

### DIFF
--- a/general/templates/general/base.html
+++ b/general/templates/general/base.html
@@ -11,6 +11,7 @@
 
             <link rel="stylesheet" href="{{ url_for('static', filename='lib/font-awesome-4.7.0/css/font-awesome.min.css') }}">
             <link rel="stylesheet" href="{{ url_for('static', filename='css/yoda-portal.css') }}">
+            <link rel="stylesheet" href="{{ url_for('static', filename='css/messages.css') }}">
             {% block style %}{% endblock style %}
 
             <script src="{{ url_for('static', filename='lib/jquery-1.11.2/js/jquery.min.js') }}"></script>
@@ -83,8 +84,14 @@
         {% block container %}
         <div class="container page">
             <div id="messages">
-                {% for message in get_flashed_messages() %}
-                    <div class="flash">{{ message }}</div>
+                {% for category, message in get_flashed_messages(with_categories=true) %}
+                {% if category is sameas 'error' %}
+                {% set category = 'danger' %}
+                {% endif %}
+                <div class="alert alert-{{ category }}">
+                    <a href="#" class="close" data-dismiss="alert" aria-label="close" title="close"></a>
+                    <span>{{ message }}</span>
+                </div>
                 {% endfor %}
             </div>
 

--- a/general/templates/general/base.html
+++ b/general/templates/general/base.html
@@ -88,8 +88,8 @@
                 {% if category is sameas 'error' %}
                 {% set category = 'danger' %}
                 {% endif %}
-                <div class="alert alert-{{ category }}">
-                    <a href="#" class="close" data-dismiss="alert" aria-label="close" title="close"></a>
+                <div class="alert alert-{{ category }} alert-dismissable">
+                    <a href="#" class="close" data-dismiss="alert" aria-label="close" title="close">&times;</a>
                     <span>{{ message }}</span>
                 </div>
                 {% endfor %}

--- a/static/css/messages.css
+++ b/static/css/messages.css
@@ -1,0 +1,59 @@
+#messages > div {
+    opacity: 1;
+    -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    filter: alpha(opacity=100);
+}
+
+#messages > .alert {
+    background-image: none !important;
+}
+
+#messages > .alert:before {
+    font-family: FontAwesome;
+    font-size: 24px;
+    float: left;
+    color: #FFF;
+    padding-right: 0.5em;
+    line-height: 1;
+}
+
+#messages > .alert-info:before {
+    content: "\f05a";
+}
+#messages > .alert-info:before,
+#messages > .alert-info {
+    color: #31708f;
+}
+
+#messages > .alert-success:before {
+    content: "\f00c";
+}
+#messages > .alert-success:before,
+#messages > .alert-success {
+    color: #3c763d;
+}
+
+#messages > .alert-warning:before {
+    content: "\f06a";
+}
+#messages > .alert-warning:before,
+#messages > .alert-warning {
+    color: #8a6d3b;
+}
+
+#messages > .alert-danger:before {
+    content: "\f071";
+}
+#messages > .alert-danger:before,
+#messages > .alert-danger {
+    color: #a94442;
+}
+
+#messages > .alert > .close {
+    font-family: FontAwesome;
+    font-size: 24px;
+}
+
+#messages > .alert > .close:before {
+    content: "\f00d";
+}

--- a/static/css/messages.css
+++ b/static/css/messages.css
@@ -48,12 +48,3 @@
 #messages > .alert-danger {
     color: #a94442;
 }
-
-#messages > .alert > .close {
-    font-family: FontAwesome;
-    font-size: 24px;
-}
-
-#messages > .alert > .close:before {
-    content: "\f00d";
-}

--- a/user/user.py
+++ b/user/user.py
@@ -59,7 +59,14 @@ def login():
 
             return redirect(redirect_target)
 
-        flash(error)
+        flash(error, 'error')
+
+    text = 'Dit is tekst'
+    lange_text = 'Dit is hele lange tekst waarvan ik hoop dat die lange ris dan de breedte van mijn scherm voor Yoda zodat er een linebreak inzit. Op die manier kan ik controleren of de css properties die ik geset heb wel goed zijn voor multiline error. Ik heb namelijk het origineel een beetje aangepast.'
+    flash(text, 'error')
+    flash(text, 'success')
+    flash(text, 'warning')
+    flash(lange_text, 'info')
 
     return render_template('user/login.html')
 

--- a/user/user.py
+++ b/user/user.py
@@ -61,13 +61,6 @@ def login():
 
         flash(error, 'error')
 
-    text = 'Dit is tekst'
-    lange_text = 'Dit is hele lange tekst waarvan ik hoop dat die lange ris dan de breedte van mijn scherm voor Yoda zodat er een linebreak inzit. Op die manier kan ik controleren of de css properties die ik geset heb wel goed zijn voor multiline error. Ik heb namelijk het origineel een beetje aangepast.'
-    flash(text, 'error')
-    flash(text, 'success')
-    flash(text, 'warning')
-    flash(lange_text, 'info')
-
     return render_template('user/login.html')
 
 


### PR DESCRIPTION
Added the styling to flash messages. 
Changes made:
- Update base.html to have messages.css included
- added messages.css
- Added a category to the flash message in user/user.py (login).
- Updated the messages tempalte in base.html: multiple messages can now be shown instead of only the first one and category 'error' has its CSS class changed to alert-danger (instead of alert-error) in order to comply with previously defined CSS classses.

NOTE: the messages now have icons. These were already in the messages.css on the PHP portal, but somehow weren't shown. I left them in.