### PR TITLE
taken out obsolete bootstrap tags navbar-inverse and navbar-header

### DIFF
--- a/general/templates/general/base.html
+++ b/general/templates/general/base.html
@@ -58,14 +58,12 @@
             </div>
         </header>
 
-        <nav class="navbar navbar-inverse navbar-static-top navbar-expand-lg yoda-navbar">
+        <nav class="navbar navbar-dark navbar-static-top navbar-expand-lg yoda-navbar">
             <div class="container">
-                <div class="navbar-header">
-                    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <a class="navbar-brand" href="{{ url_for('general_bp.index') }}">Yoda Portal</a>
-                </div>
+                <a class="navbar-brand" href="{{ url_for('general_bp.index') }}">Yoda Portal</a>
+                <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
                 <div id="navbar" class="collapse navbar-collapse">
                     <ul class="nav navbar-nav">
                         {% for module in config.get('modules') %}


### PR DESCRIPTION
Het hamburgertje verschijnt nu (navbar-inverse bleek obsolete).
Omdat het niet naar rechts sprong, heb ik ook de div met class navbar-header verwijderd. Ook dit is obsolete in deze versie van bootstrap)