### PR TITLE
Check authorization in the statistics view

### DIFF
--- a/stats/stats.py
+++ b/stats/stats.py
@@ -20,10 +20,16 @@ def index():
     resource_tiers_response = api.call('resource_resource_and_tier_data', data={})
     group_response = api.call('resource_list_groups', data={})
     category_response = api.call('resource_category_stats', data={})
+
+    has_access = False
+    if (resource_tiers_response['data'] or group_response['data'] or category_response['data']):
+        has_access = True
+
     return render_template('stats/stats.html',
                            resources=resource_tiers_response['data'],
                            groups=group_response['data'],
-                           categories=category_response['data'])
+                           categories=category_response['data'],
+                           access=has_access)
 
 
 @stats_bp.route('get_tiers', methods=['GET'])

--- a/stats/templates/stats/stats.html
+++ b/stats/templates/stats/stats.html
@@ -15,6 +15,12 @@
 {% block content %}
     <h1>Statistics</h1>
 
+    {% if access is sameas false %}
+    <div class="alert alert-danger" role="alert">
+        You are not authorized to view any (group) statistics on this system.
+    </div>
+    {% endif %}
+
     {% if resources %}
     <div class="row mb-4">
         <div class="col-md-5">
@@ -85,6 +91,7 @@
     </div>
     {% endif %}
 
+    {% if groups %}
     <div class="row">
         <div class="col-md-5">
             <div class="card">
@@ -116,4 +123,5 @@
             </div>
         </div>
     </div>
+    {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Cosmetic issue: in Yoda 1.7, if a regular user is not a member of any group, the statistics module still asks to select a group.

Solution: 
![2021-12-13 11_05_23-Window](https://user-images.githubusercontent.com/50098174/145793365-de83d802-5a75-48c0-a055-0fcd44a2bf82.png)

