### PR TITLE
remove tabIndex in modal definition to fix select2 issue

### DIFF
--- a/group_manager/templates/group_manager/index.html
+++ b/group_manager/templates/group_manager/index.html
@@ -162,7 +162,7 @@
 	</div>
 </div>
 
-<div class="modal fade" id="modal-group-create" tabindex="-1" role="dialog">
+<div class="modal fade" id="modal-group-create" role="dialog">
 	<div class="modal-dialog">
 		<div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
This fix, removing tabIndex, was the first suggestion I found on stackoverlfow.
It was mentioned that the escape button would not work for closing the dialog as the only downside of this fix.
However, this still works.
Roy mentioned that this might be overtaken by deploying a newer version of select2. And he would look into this.
So this fix might become obsolete.
Any how ... this does the trick for the time being 

Gr,
Harm