### PR TITLE
fixed lead/trailing whitespaces problem in usernames as entered by admin

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -981,7 +981,7 @@ $(function() {
                 return;
 
             var groupName = $(el).find('#f-user-create-group').val();
-            var  userName = $(el).find('#f-user-create-name' ).val();
+            var  userName = $(el).find('#f-user-create-name' ).val().trim();
 
             if (!userName.match(/^([a-z.]+|[a-z0-9_.-]+@[a-z0-9_.-]+)(#[a-zA-Z0-9_-]+)?$/)) {
                 alert('Please enter either an e-mail address or a name consisting only of lowercase chars and dots.');


### PR DESCRIPTION
fix for trailing and leading spaces entered by an admin that may be discarded and not interfere with saving a new username anymore