### PR TITLE
YDA-4925: delete expired tokens

### DIFF
--- a/user/static/user/js/data_access.js
+++ b/user/static/user/js/data_access.js
@@ -20,21 +20,24 @@ $(document).ready(function() {
         let button = document.getElementById('generateButton');
         button.setAttribute("hidden", true);
 
-        Yoda.call("token_generate", {"label": label}, {"quiet": true}).then(
-            (data) => {
-                $('#f-token').val(data);
-                let p = document.getElementById('passwordOk');
-                p.removeAttribute("hidden");
-            },
-            (error) => {
-                let error_id = "passwordGenerateError";
-                if (error.status === "error_TokenExistsError") {
-                    error_id = "passwordLabelError";
+        Yoda.call("token_delete_expired",{}).then(response => {
+            return Yoda.call("token_generate", {"label": label}, {"quiet": true}).then(
+                (data) => {
+                    $('#f-token').val(data);
+                    let p = document.getElementById('passwordOk');
+                    p.removeAttribute("hidden");
+                },
+                (error) => {
+                    let error_id = "passwordGenerateError";
+                    if (error.status === "error_TokenExistsError") {
+                        error_id = "passwordLabelError";
+                    }
+                    let p = document.getElementById(error_id);
+                    p.removeAttribute("hidden");
+                    button.removeAttribute("hidden");
                 }
-                let p = document.getElementById(error_id);
-                p.removeAttribute("hidden");
-                button.removeAttribute("hidden");
-            });
+            );
+        });
     });
 
     $('.btn-copy-to-clipboard').click(function(event){


### PR DESCRIPTION
Delete expired tokens before generating new ones, in order to prevent name conflicts between new tokens and expired tokens that are no longer visible to users.