### PR TITLE
YDA-5151: fix portal when OIDC is disabled

### DIFF
--- a/user/user.py
+++ b/user/user.py
@@ -347,7 +347,7 @@ def callback() -> Response:
 def should_redirect_to_oidc(username: str) -> bool:
     """Check if user should be redirected to OIDC based on domain."""
     if '@' in username:
-        domains: List[str] = app.config.get('OIDC_DOMAINS')
+        domains: List[str] = app.config.get('OIDC_DOMAINS', [])
         user_domain = username.split('@')[1]
         if app.config.get('OIDC_ENABLED') and user_domain in domains:
             return True
@@ -434,7 +434,7 @@ def release_session(response: Response) -> Response:
 
 
 def get_login_placeholder() -> str:
-    oidc_domains = app.config.get("OIDC_DOMAINS")
+    oidc_domains = app.config.get("OIDC_DOMAINS", [])
     if len(oidc_domains) == 0 or oidc_domains[0] == "":
         return "j.a.smith@uu.nl"
     else:


### PR DESCRIPTION
Unhandled portal exception on on login when OIDC was disabled, because in that case OIDC_DOMAINS is not present in the configuration.