### PR TITLE
Proof of concept with iRODS session cleanup

### DIFF
--- a/connman.py
+++ b/connman.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-__copyright__ = 'Copyright (c) 2021-2022, Utrecht University'
+__copyright__ = 'Copyright (c) 2021-2023, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import threading
@@ -9,7 +9,8 @@ from typing import Dict, Optional
 
 from irods.session import iRODSSession
 
-TTL = 60 * 30
+TTL = 60 * 30   # Time to live (TTL) for Flask sessions.
+IRODS_TTL = 60  # Time to live (TTL) for iRODS sessions.
 
 
 class Session(object):
@@ -19,18 +20,19 @@ class Session(object):
         :param sid:   Flask session identifier
         :param irods: iRODS session
         """
-        self.sid: int            = sid
-        self.irods: iRODSSession = irods
-        self.time: float         = time.time()
-        self.lock                = threading.Lock()
+        self.sid: int             = sid               # Flask session identifier
+        self.time: float          = time.time()       # Flask session start time
+        self.irods: iRODSSession  = irods             # iRODS session
+        self.irods_time: float    = time.time()       # iRODS session start time
+        self.lock: threading.Lock = threading.Lock()
 
     def __del__(self) -> None:
         self.irods.cleanup()
-        print(f"[gc/logout]: Dropped iRODS session of session {self.sid}")
+        print(f"[gc/logout]: Cleanup session {self.sid}")
 
 
 sessions: Dict[int, Session] = dict()  # Custom session dict instead of Flask session (cannot pickle iRODS session)
-lock = threading.Lock()
+lock: threading.Lock = threading.Lock()
 
 
 def gc() -> None:
@@ -39,7 +41,15 @@ def gc() -> None:
         with lock:
             t = time.time()
             global sessions
+
+            # Remove sessions that exceed the Flask session TTL.
             sessions = {k: v for k, v in sessions.items() if t - v.time < TTL or v.lock.locked()}
+
+            # Cleanup iRODS sessions that exceed the iRODS session TTL.
+            for _, s in sessions.items():
+                if t - s.irods_time > IRODS_TTL and not s.lock.locked():
+                    s.irods.cleanup()
+                    s.irods_time = time.time()
 
         time.sleep(1)
 
@@ -69,6 +79,7 @@ def add(sid: int, irods: iRODSSession) -> None:
     s: Session = Session(sid, irods)
     sessions[sid] = s
     s.time = time.time()
+    s.irods_time = time.time()
     s.lock.acquire()
     print(f"[login]: Successfully connected to iRODS for session {sid}'")
 
@@ -82,6 +93,7 @@ def release(sid: int) -> None:
     if sid in sessions:
         s: Session = sessions[sid]
         s.time = time.time()
+        s.irods_time = time.time()
         s.lock.release()
 
 
@@ -93,3 +105,15 @@ def clean(sid: int) -> None:
     global sessions
     if sid in sessions:
         del sessions[sid]
+
+
+def extend(sid: int) -> None:
+    """Extend session TTLs.
+
+    :param sid: Flask session identifier
+    """
+    global sessions
+    if sid in sessions:
+        s: Session = sessions[sid]
+        s.time = time.time()
+        s.irods_time = time.time()

--- a/deposit/deposit.py
+++ b/deposit/deposit.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 
-__copyright__ = 'Copyright (c) 2021-2022, Utrecht University'
+__copyright__ = 'Copyright (c) 2021-2023, Utrecht University'
 __license__ = 'GPLv3, see LICENSE'
 
 import io
 from typing import Iterator
 
-from flask import abort, Blueprint, g, redirect, render_template, request, Response, stream_with_context, url_for
+from flask import abort, Blueprint, g, redirect, render_template, request, Response, session, stream_with_context, url_for
 from irods.exception import CAT_NO_ACCESS_PERMISSION
 
 import api
+import connman
 
 deposit_bp = Blueprint('deposit_bp', __name__,
                        template_folder='templates',
@@ -56,17 +57,16 @@ def data() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
-    session = g.irods
-
     READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
 
     def read_file_chunks(path: str) -> Iterator[bytes]:
-        obj = session.data_objects.get(path)
+        obj = g.irods.data_objects.get(path)
         try:
             with obj.open('r') as fd:
                 while True:
                     buf = fd.read(READ_BUFFER_SIZE)
                     if buf:
+                        connman.extend(session.sid)
                         yield buf
                     else:
                         break
@@ -75,7 +75,7 @@ def download() -> Response:
         except Exception:
             abort(500)
 
-    if session.data_objects.exists(path):
+    if g.irods.data_objects.exists(path):
         return Response(
             stream_with_context(read_file_chunks(path)),
             headers={

--- a/vault/vault.py
+++ b/vault/vault.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 
-__copyright__ = 'Copyright (c) 2021-2022, Utrecht University'
+__copyright__ = 'Copyright (c) 2021-2023, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import io
 from typing import Iterator
 from uuid import UUID
 
-from flask import abort, Blueprint, g, render_template, request, Response, stream_with_context
+from flask import abort, Blueprint, g, render_template, request, Response, session, stream_with_context
+from irods.exception import CAT_NO_ACCESS_PERMISSION
 
 import api
+import connman
 
 vault_bp = Blueprint('vault_bp', __name__,
                      template_folder='templates',
@@ -34,21 +36,25 @@ def index() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
-    session = g.irods
-
     READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
 
     def read_file_chunks(path: str) -> Iterator[bytes]:
-        obj = session.data_objects.get(path)
-        with obj.open('r') as fd:
-            while True:
-                buf = fd.read(READ_BUFFER_SIZE)
-                if buf:
-                    yield buf
-                else:
-                    break
+        obj = g.irods.data_objects.get(path)
+        try:
+            with obj.open('r') as fd:
+                while True:
+                    buf = fd.read(READ_BUFFER_SIZE)
+                    if buf:
+                        connman.extend(session.sid)
+                        yield buf
+                    else:
+                        break
+        except CAT_NO_ACCESS_PERMISSION:
+            abort(403)
+        except Exception:
+            abort(500)
 
-    if session.data_objects.exists(path):
+    if g.irods.data_objects.exists(path):
         return Response(
             stream_with_context(read_file_chunks(path)),
             headers={


### PR DESCRIPTION
These changes clean iRODS sessions after being inactive for 60 seconds. When communicating with iRODS after 60 seconds of inactivity user is authenticated automagically if it is inside the Flask session TTL (30 minutes).

While downloading files the TTLs are extended to prevent cleaning of sessions during a download. This assumes that reading a single block druing a download does not take longer then 60 seconds.

![Screenshot_2023-07-20_12-17-51](https://github.com/UtrechtUniversity/yoda-portal/assets/29246264/509e6c4b-ebd1-42a3-b58d-c348881adab6)

![Screenshot_2023-07-21_15-30-03](https://github.com/UtrechtUniversity/yoda-portal/assets/29246264/49cc39d1-69b1-44b6-a8a8-da4e8da4d95b)
