### PR TITLE
fixed not showing datamanager-option when creating group

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -568,7 +568,11 @@ $(function () {
 
     $('#f-group-create-sram-group').prop('checked', false)
 
-    $('#f-group-create-prefix-datamanager').addClass('hidden')
+    if (that.canCreateDatamanagerGroup(category)) { 
+      $('#f-group-create-prefix-datamanager').removeClass('hidden') 
+    } else { 
+      $('#f-group-create-prefix-datamanager').addClass('hidden') 
+    }
 
     $('#f-group-create-schema-id').select2('val', that.schemaIdDefault)
     $('#f-group-create-expiration-date').val('')


### PR DESCRIPTION
Correct options are set for group-prefix when clicking 'add group' button.
