### PR TITLE
Intake module: update experiment type key

### DIFF
--- a/intake/templates/intake/intake.html
+++ b/intake/templates/intake/intake.html
@@ -263,7 +263,7 @@
                             </td>
                             <td>{{ data.datasetCreateDateFormatted }}</td>
                             <td>{{ data.pseudocode }}</td>
-                            <td>{{ data.expType }}</td>
+                            <td>{{ data.experiment_type }}</td>
                             <td>{{ data.wave }}</td>
                             <td>{{ data.version }}</td>
                             <td style="text-align: right;">{{ data.objects }}</td>


### PR DESCRIPTION
We used to have two keys for experiment type: expType (legacy) and experiment_type (the normal one). Removing the legacy name so we don't need two keys anymore.