### PR TITLE
Use table-active when selecting next group after group delete

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -1800,7 +1800,7 @@ $(function () {
          */
     onClickGroupDelete: function (el) {
       const groupName = $('#group-list .group.active').attr('data-name')
-      const nextGroupName = $('#result-user-search-groups .user-search-result-group.active').next().attr('user-search-result-group')
+      const nextGroupName = $('#result-user-search-groups .user-search-result-group.table-active').next().attr('user-search-result-group')
 
       $('#group-list .group.active')
         .addClass('delete-pending disabled')


### PR DESCRIPTION
Fixes issue introduced with YDA-5558 theme adjustments, where it was not automatically moving to the next group after deleting a group.