### PR TITLE
YDA-5651: extract parameter for .part uploads

### DIFF
--- a/deposit/static/deposit/js/data.js
+++ b/deposit/static/deposit/js/data.js
@@ -195,6 +195,7 @@ $(function () {
     target: '/research/upload',
     chunkSize: 25 * 1024 * 1024,
     forceChunkSize: true,
+    testChunks: false,         // Disabled because of need to be able to overwrite files with different content
     simultaneousUploads: 1,
     query: { csrf_token: Yoda.csrf.tokenValue, filepath: '' }
   })

--- a/research/research.py
+++ b/research/research.py
@@ -159,9 +159,10 @@ def upload_get() -> Response:
     object_path = build_object_path(filepath, flow_relative_path, flow_filename)
 
     # Partial file name for chunked uploads.
-    if flow_total_chunks > 1:
+    if flow_total_chunks > 1 and app.config.get('UPLOAD_PART_FILES'):
         object_path = f"{object_path}.part"
-    else:
+
+    if flow_total_chunks == 1:
         # Ensuring single chunk files get to the overwrite stage as well
         response = make_response(jsonify({"message": "Chunk not found"}), 204)
         response.headers["Content-Type"] = "application/json"
@@ -207,7 +208,7 @@ def upload_post() -> Response:
     object_path = build_object_path(filepath, flow_relative_path, flow_filename)
 
     # Partial file name for chunked uploads.
-    if flow_total_chunks > 1:
+    if flow_total_chunks > 1 and app.config.get('UPLOAD_PART_FILES'):
         object_path = f"{object_path}.part"
 
     # Get the chunk data.
@@ -235,7 +236,7 @@ def upload_post() -> Response:
             return response
 
     # Rename partial file name when complete for chunked uploads.
-    if flow_total_chunks > 1 and flow_total_chunks == flow_chunk_number:
+    if app.config.get('UPLOAD_PART_FILES') and flow_total_chunks > 1 and flow_total_chunks == flow_chunk_number:
         final_object_path = build_object_path(filepath, flow_relative_path, flow_filename)
         try:
             # overwriting doesn't work using the move command, therefore unlink the previous file first

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -287,6 +287,7 @@ $(function () {
     chunkSize: 25 * 1024 * 1024,
     forceChunkSize: true,
     simultaneousUploads: 1,
+    testChunks: false,         // Disabled because of need to be able to overwrite files with different content
     query: { csrf_token: Yoda.csrf.tokenValue, filepath: '' }
   })
   // Flow.js isn't supported, fall back on a different method


### PR DESCRIPTION
Add a parameter so that temporarily using a .part filename for files that are being uploaded in the portal can be disabled. This can be necessary on systems where renaming large .part data objects to their final name is very slow, such as S3 object storage systems with the S3 storage plugin in consistent mode.