### PR TITLE
YDA-5763: fix support for utf-8 downloads

### DIFF
--- a/deposit/deposit.py
+++ b/deposit/deposit.py
@@ -4,6 +4,7 @@ __copyright__ = 'Copyright (c) 2021-2024, Utrecht University'
 __license__ = 'GPLv3, see LICENSE'
 
 import io
+import urllib.parse
 from typing import Iterator
 
 from flask import abort, Blueprint, g, redirect, render_template, request, Response, session, stream_with_context, url_for
@@ -72,6 +73,7 @@ def data() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
+    quoted_filename = urllib.parse.quote(filename)
 
     def read_file_chunks(data_object: iRODSDataObject) -> Iterator[bytes]:
         READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
@@ -97,9 +99,9 @@ def download() -> Response:
         return Response(
             stream_with_context(read_file_chunks(data_object)),
             headers={
-                'Content-Disposition': f'attachment; filename={filename}',
+                'Content-Disposition': "attachment; filename*=UTF-8''" + quoted_filename,
                 'Content-Length': f'{size}',
-                'Content-Type': 'application/octet'
+                'Content-Type': 'application/octet-stream'
             }
         )
     else:

--- a/fileviewer/fileviewer.py
+++ b/fileviewer/fileviewer.py
@@ -6,6 +6,7 @@ __license__   = 'GPLv3, see LICENSE'
 import io
 import queue
 import threading
+import urllib.parse
 from typing import Iterator
 
 from flask import (
@@ -80,6 +81,7 @@ def index() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
+    quoted_filename = urllib.parse.quote(filename)
 
     def read_file_chunks(data_object: iRODSDataObject) -> Iterator[bytes]:
         READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
@@ -105,9 +107,9 @@ def download() -> Response:
         return Response(
             stream_with_context(read_file_chunks(data_object)),
             headers={
-                'Content-Disposition': f'attachment; filename={filename}',
+                'Content-Disposition': "attachment; filename*=UTF-8''" + quoted_filename,
                 'Content-Length': f'{size}',
-                'Content-Type': 'application/octet'
+                'Content-Type': 'application/octet-stream'
             }
         )
     else:

--- a/research/research.py
+++ b/research/research.py
@@ -7,6 +7,7 @@ import io
 import os
 import queue
 import threading
+import urllib.parse
 from typing import Iterator
 
 from flask import (
@@ -86,6 +87,7 @@ def index() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
+    quoted_filename = urllib.parse.quote(filename)
 
     def read_file_chunks(data_object: iRODSDataObject) -> Iterator[bytes]:
         READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
@@ -111,9 +113,9 @@ def download() -> Response:
         return Response(
             stream_with_context(read_file_chunks(data_object)),
             headers={
-                'Content-Disposition': f'attachment; filename={filename}',
+                'Content-Disposition': "attachment; filename*=UTF-8''" + quoted_filename,
                 'Content-Length': f'{size}',
-                'Content-Type': 'application/octet'
+                'Content-Type': 'application/octet-stream'
             }
         )
     else:

--- a/vault/vault.py
+++ b/vault/vault.py
@@ -4,6 +4,7 @@ __copyright__ = 'Copyright (c) 2021-2023, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import io
+import urllib.parse
 from typing import Iterator
 from uuid import UUID
 
@@ -37,6 +38,7 @@ def index() -> Response:
 def download() -> Response:
     path = '/' + g.irods.zone + '/home' + request.args.get('filepath')
     filename = path.rsplit('/', 1)[1]
+    quoted_filename = urllib.parse.quote(filename)
 
     def read_file_chunks(data_object: iRODSDataObject) -> Iterator[bytes]:
         READ_BUFFER_SIZE = 1024 * io.DEFAULT_BUFFER_SIZE
@@ -62,9 +64,9 @@ def download() -> Response:
         return Response(
             stream_with_context(read_file_chunks(data_object)),
             headers={
-                'Content-Disposition': f'attachment; filename={filename}',
+                'Content-Disposition': "attachment; filename*=UTF-8''" + quoted_filename,
                 'Content-Length': f'{size}',
-                'Content-Type': 'application/octet'
+                'Content-Type': 'application/octet-stream'
             }
         )
     else:


### PR DESCRIPTION
Add support for downloading data objects with a name that has non-ASCII characters. These need to be encoded in the Content-Disposition header. Also fix content type name.