### PR TITLE
Fix internal error in datarequest when user has no access

### DIFF
--- a/datarequest/datarequest.py
+++ b/datarequest/datarequest.py
@@ -110,7 +110,7 @@ def view(request_id: str) -> Response:
     request_info = api.call('datarequest_get', {'request_id': request_id})['data']
     if not request_info:
         abort(403)
-        
+
     request_status       = request_info['requestStatus']
     human_request_status = human_readable_status[request_status].value
     available_documents  = request_info['requestAvailableDocuments']

--- a/datarequest/datarequest.py
+++ b/datarequest/datarequest.py
@@ -109,6 +109,8 @@ def view(request_id: str) -> Response:
 
     request_info         = api.call('datarequest_get', {'request_id': request_id})['data']
     request_status       = request_info['requestStatus']
+    if request_status == 'forbidden':
+        abort(403)
     human_request_status = human_readable_status[request_status].value
     available_documents  = request_info['requestAvailableDocuments']
     request_type         = request_info['requestType']

--- a/datarequest/datarequest.py
+++ b/datarequest/datarequest.py
@@ -107,10 +107,11 @@ def view(request_id: str) -> Response:
     if not is_project_manager and not is_datamanager and not is_dac_member and not is_request_owner:
         abort(403)
 
-    request_info         = api.call('datarequest_get', {'request_id': request_id})['data']
-    request_status       = request_info['requestStatus']
-    if request_status == 'forbidden':
+    request_info = api.call('datarequest_get', {'request_id': request_id})['data']
+    if not request_info:
         abort(403)
+        
+    request_status       = request_info['requestStatus']
     human_request_status = human_readable_status[request_status].value
     available_documents  = request_info['requestAvailableDocuments']
     request_type         = request_info['requestType']


### PR DESCRIPTION
In Yoda 1.9.3, navigating to a data request that the present user does not have access to results in an internal error being shown.

Now, this is fixed and shows 

![image](https://github.com/user-attachments/assets/25ba0153-6f61-4b9f-b5d0-65c924eb05eb)
