### PR TITLE
Log api calls and results on development

### DIFF
--- a/general/templates/general/base.html
+++ b/general/templates/general/base.html
@@ -22,7 +22,8 @@
             {% endif %}
             <script>
                 Yoda.csrf = {tokenName: 'csrf_token', tokenValue: '{{ csrf_token() }}'};
-                Yoda.textFileExtensions = {{ config.get('TEXT_FILE_EXTENSIONS') | safe }}
+                Yoda.textFileExtensions = {{ config.get('TEXT_FILE_EXTENSIONS') | safe }};
+                Yoda.version = '{{ config.get('YODA_VERSION') }}';
                 {% if g.user %}
                 Yoda.basePath = '/{{ g.irods.zone }}/home';
                 Yoda.user = {


### PR DESCRIPTION
Add Yoda.version variable back. Fix bug that api calls were not logged in the portal on development