### PR TITLE
Yda 5894 hide download buttons when no checksum report

### DIFF
--- a/deposit/static/deposit/js/data.js
+++ b/deposit/static/deposit/js/data.js
@@ -158,6 +158,8 @@ $(function () {
 
     $('#showChecksumReport .collection').text(folder)
     $('#showChecksumReport .modal-body #checksumReport').html('')
+    $('#showChecksumReport .modal-footer .download-report-text').addClass('d-none')
+    $('#showChecksumReport .modal-footer .download-report-csv').addClass('d-none')
     $('#showChecksumReport .modal-footer .download-report-text').attr('href', downloadUrl + '&format=text')
     $('#showChecksumReport .modal-footer .download-report-csv').attr('href', downloadUrl + '&format=csv')
 
@@ -167,11 +169,15 @@ $(function () {
 
       table += '<thead><tr><th>Filename</th><th>Size</th><th>Checksum</th></tr></thead>'
       $.each(data, function (index, obj) {
-        table += `<tr>
-                     <td>${obj.name}</td>
-                     <td>${obj.size}</td>
-                     <td>${obj.checksum}</td>
+        if (data.length > 0) {
+          table += `<tr>
+                    <td>${obj.name}</td>
+                    <td>${obj.size}</td>
+                    <td>${obj.checksum}</td>
                 </tr>`
+          $('#showChecksumReport .modal-footer .download-report-text').removeClass('d-none')
+          $('#showChecksumReport .modal-footer .download-report-csv').removeClass('d-none')
+        }
       })
       table += '</tbody></table>'
 

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -184,8 +184,8 @@ $(function () {
 
     $('#showChecksumReport .collection').text(folder)
     $('#showChecksumReport .modal-body #checksumReport').html('')
-    $('#showChecksumReport .modal-footer .download-report-text').addClass('d-none');
-    $('#showChecksumReport .modal-footer .download-report-csv').addClass('d-none');
+    $('#showChecksumReport .modal-footer .download-report-text').addClass('d-none')
+    $('#showChecksumReport .modal-footer .download-report-csv').addClass('d-none')
     $('#showChecksumReport .modal-footer .download-report-text').attr('href', downloadUrl + '&format=text')
     $('#showChecksumReport .modal-footer .download-report-csv').attr('href', downloadUrl + '&format=csv')
 
@@ -201,8 +201,8 @@ $(function () {
                       <td>${obj.size}</td>
                       <td>${obj.checksum}</td>
                   </tr>`
-          $('#showChecksumReport .modal-footer .download-report-text').removeClass('d-none');
-          $('#showChecksumReport .modal-footer .download-report-csv').removeClass('d-none');
+          $('#showChecksumReport .modal-footer .download-report-text').removeClass('d-none')
+          $('#showChecksumReport .modal-footer .download-report-csv').removeClass('d-none')
         }
       })
       table += '</tbody></table>'

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -184,6 +184,8 @@ $(function () {
 
     $('#showChecksumReport .collection').text(folder)
     $('#showChecksumReport .modal-body #checksumReport').html('')
+    $('#showChecksumReport .modal-footer .download-report-text').addClass('d-none');
+    $('#showChecksumReport .modal-footer .download-report-csv').addClass('d-none');
     $('#showChecksumReport .modal-footer .download-report-text').attr('href', downloadUrl + '&format=text')
     $('#showChecksumReport .modal-footer .download-report-csv').attr('href', downloadUrl + '&format=csv')
 
@@ -193,11 +195,15 @@ $(function () {
 
       table += '<thead><tr><th>Filename</th><th>Size</th><th>Checksum</th></tr></thead>'
       $.each(data, function (index, obj) {
-        table += `<tr>
-                     <td>${obj.name}</td>
-                     <td>${obj.size}</td>
-                     <td>${obj.checksum}</td>
-                </tr>`
+        if (data.length > 0) {
+          table += `<tr>
+                      <td>${obj.name}</td>
+                      <td>${obj.size}</td>
+                      <td>${obj.checksum}</td>
+                  </tr>`
+          $('#showChecksumReport .modal-footer .download-report-text').removeClass('d-none');
+          $('#showChecksumReport .modal-footer .download-report-csv').removeClass('d-none');
+        }
       })
       table += '</tbody></table>'
 

--- a/vault/static/vault/js/vault.js
+++ b/vault/static/vault/js/vault.js
@@ -49,6 +49,8 @@ $(function () {
 
     $('#showChecksumReport .collection').text(folder)
     $('#showChecksumReport .modal-body #checksumReport').html('')
+    $('#showChecksumReport .modal-footer .download-report-text').addClass('d-none')
+    $('#showChecksumReport .modal-footer .download-report-csv').addClass('d-none')
     $('#showChecksumReport .modal-footer .download-report-text').attr('href', downloadUrl + '&format=text')
     $('#showChecksumReport .modal-footer .download-report-csv').attr('href', downloadUrl + '&format=csv')
 
@@ -58,11 +60,15 @@ $(function () {
 
       table += '<thead><tr><th>Filename</th><th>Size</th><th>Checksum</th></tr></thead>'
       $.each(data, function (index, obj) {
-        table += `<tr>
-                     <td>${obj.name}</td>
-                     <td>${obj.size}</td>
-                     <td>${obj.checksum}</td>
+        if (data.length > 0) {
+          table += `<tr>
+                    <td>${obj.name}</td>
+                    <td>${obj.size}</td>
+                    <td>${obj.checksum}</td>
                 </tr>`
+          $('#showChecksumReport .modal-footer .download-report-text').removeClass('d-none')
+          $('#showChecksumReport .modal-footer .download-report-csv').removeClass('d-none')
+        }
       })
       table += '</tbody></table>'
 


### PR DESCRIPTION
Jira: https://utrechtuniversity.atlassian.net/browse/YDA-5894

**Issue**
When the “Checksum report” is opened and there is not yet a checksum created I am able to download an “empty” file (both as text and CSV).

**Solution**
Now, the download text or csv buttons are hidden when there is no checksum report