### PR TITLE
Yda 5889 research upload file with non utf 8 name

### DIFF
--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -437,7 +437,7 @@ $(function () {
       }
     }
 
-    $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>");
+    $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>")
     const $self = $('#' + file.uniqueIdentifier)
     $self.find('.upload-btns').hide()
     const path = $('.upload').attr('data-path')

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -408,6 +408,14 @@ $(function () {
             $self.find('.msg').html('<i class="fa-solid fa-spinner fa-spin fa-fw"></i>')
           })
 
+          try {
+            decodeURIComponent(escape(file.name))
+          } catch (e) {
+            if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
+              $('#nonUTF-8FilenameWarning').removeClass('hidden')
+            }
+          }
+          
           // No Overwrite btn
           $self.find('.upload-no-overwrite').on('click', function () {
             file.cancel()
@@ -429,13 +437,6 @@ $(function () {
     browse(path)
   })
   r.on('fileSuccess', function (file, message) {
-    try {
-      decodeURIComponent(escape(file.name))
-    } catch (e) {
-      if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
-        $('#nonUTF-8FilenameWarning').removeClass('hidden')
-      }
-    }
 
     $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>")
     const $self = $('#' + file.uniqueIdentifier)

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -322,6 +322,7 @@ $(function () {
     r.cancel()
     $('#files').html('')
     $('#uploads').addClass('hidden')
+    $('#nonUTF-8FilenameWarning').addClass('hidden')
     // clear information present for next time dialog is presented
     $('.uploads-progress-information').html('')
     $('.uploads-total-progress-bar').css('width', '0%')
@@ -431,15 +432,11 @@ $(function () {
     try {
       decodeURIComponent(escape(file.name));
     } catch (e) {
-      $('#' + file.uniqueIdentifier).prepend(`
-          <div class="container">
-            <div class="alert alert-primary">
-              Uploaded file will be renamed because not all non UTF-8 characters are supported.
-            </div>
-          </div>
-      `);
+      if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
+        $('#nonUTF-8FilenameWarning').removeClass('hidden')
+      }
     }
-    
+
     $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>");
     const $self = $('#' + file.uniqueIdentifier)
     $self.find('.upload-btns').hide()

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -430,7 +430,7 @@ $(function () {
   })
   r.on('fileSuccess', function (file, message) {
     try {
-      decodeURIComponent(escape(file.name));
+      decodeURIComponent(escape(file.name))
     } catch (e) {
       if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
         $('#nonUTF-8FilenameWarning').removeClass('hidden')

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -415,7 +415,7 @@ $(function () {
               $('#nonUTF-8FilenameWarning').removeClass('hidden')
             }
           }
-          
+
           // No Overwrite btn
           $self.find('.upload-no-overwrite').on('click', function () {
             file.cancel()
@@ -437,7 +437,6 @@ $(function () {
     browse(path)
   })
   r.on('fileSuccess', function (file, message) {
-
     $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>")
     const $self = $('#' + file.uniqueIdentifier)
     $self.find('.upload-btns').hide()

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -428,7 +428,19 @@ $(function () {
     browse(path)
   })
   r.on('fileSuccess', function (file, message) {
-    $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>")
+    try {
+      decodeURIComponent(escape(file.name));
+    } catch (e) {
+      $('#' + file.uniqueIdentifier).prepend(`
+          <div class="container">
+            <div class="alert alert-primary">
+              Uploaded file will be renamed because not all non UTF-8 characters are supported.
+            </div>
+          </div>
+      `);
+    }
+    
+    $('#' + file.uniqueIdentifier + ' .msg').html("<span class='text-success'>Upload complete</span>");
     const $self = $('#' + file.uniqueIdentifier)
     $self.find('.upload-btns').hide()
     const path = $('.upload').attr('data-path')

--- a/research/templates/research/browse.html
+++ b/research/templates/research/browse.html
@@ -322,7 +322,7 @@
             </div>
             <div class="modal-body">
                 <div id="nonUTF-8FilenameWarning" class="hidden alert alert-primary">
-                    Uploaded file(s) containing non UTF-8 characters will be renamed because not all non UTF-8 characters are supported.
+                    Uploaded filenames contain unsupported characters and are renamed for compatibility.
                 </div>
                 <div id="files"></div>
             </div>

--- a/research/templates/research/browse.html
+++ b/research/templates/research/browse.html
@@ -321,6 +321,9 @@
                 <button type="button" class="btn-close btn-close-uploads-overview" data-bs-dismiss="modal" aria-label="Close" title="Close"></button>
             </div>
             <div class="modal-body">
+                <div id="nonUTF-8FilenameWarning" class="hidden alert alert-primary">
+                    Uploaded file(s) containing non UTF-8 characters will be renamed because not all non UTF-8 characters are supported.
+                </div>
                 <div id="files"></div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
**Summary**
In the research module, after uploading a file with a non-UTF-8 encoded file name, when downloading the file from the portal the downloaded file has a different file name, a UTF-8 encoded file name.

**Work done**
Added a warning when a user (e.g. researcher) uploads a file with a name containing non UTF-8 characters, or a folder which contains files with names containing non UTF-8 characters.

This is to inform the user that the files with such names will be renamed because not all non UTF-8 characters are supported.