### PR TITLE
Yda 5889 fix for utf8 warning

### DIFF
--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -348,6 +348,14 @@ $(function () {
         const folderName = file.relativePath.substring(0, file.relativePath.indexOf('/'))
         let overwrite = false
 
+        try {
+          decodeURIComponent(escape(file.name))
+        } catch (e) {
+          if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
+            $('#nonUTF-8FilenameWarning').removeClass('hidden')
+          }
+        }
+        
         const $self = $('#' + file.uniqueIdentifier)
         // Pause btn
         $self.find('.upload-pause').on('click', function () {
@@ -385,6 +393,7 @@ $(function () {
             overwrite = true
           }
         }
+
         // Check for apostrophe in folder name
         if (folders.indexOf('\'') > -1) {
           // It seems like you must first pause, then cancel
@@ -407,14 +416,6 @@ $(function () {
             $self.find('.upload-cancel').show()
             $self.find('.msg').html('<i class="fa-solid fa-spinner fa-spin fa-fw"></i>')
           })
-
-          try {
-            decodeURIComponent(escape(file.name))
-          } catch (e) {
-            if ($('#nonUTF-8FilenameWarning').hasClass('hidden')) {
-              $('#nonUTF-8FilenameWarning').removeClass('hidden')
-            }
-          }
 
           // No Overwrite btn
           $self.find('.upload-no-overwrite').on('click', function () {

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -393,7 +393,6 @@ $(function () {
             overwrite = true
           }
         }
-
         // Check for apostrophe in folder name
         if (folders.indexOf('\'') > -1) {
           // It seems like you must first pause, then cancel

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -355,7 +355,7 @@ $(function () {
             $('#nonUTF-8FilenameWarning').removeClass('hidden')
           }
         }
-        
+
         const $self = $('#' + file.uniqueIdentifier)
         // Pause btn
         $self.find('.upload-pause').on('click', function () {


### PR DESCRIPTION
**Problem**

Warning was shown when uploading a file to overwrite an existing file.

Now, it is also shown for uploading files which do not exist, not only when uploading files to overwrite existing ones.