### PR TITLE
Yda 5942 add user friendly messages csv import

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -374,7 +374,8 @@ async function processImportedRow (row) {
         allow_update: $('#import-allow-updates').is(':checked'),
         delete_users: $('#import-delete-users').is(':checked')
       },
-      { quiet: true, rawResult: true })
+      { quiet: true, rawResult: true }
+    )
     // Successful import -> set correct classes and feedback to inform user
     row.addClass('import-groupname-done')
     $('#processed-indicator-' + groupname).html('<i class="fa-solid fa-check"></i>')

--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -374,8 +374,7 @@ async function processImportedRow (row) {
         allow_update: $('#import-allow-updates').is(':checked'),
         delete_users: $('#import-delete-users').is(':checked')
       },
-      { quiet: true, rawResult: true }
-    )
+      { quiet: true, rawResult: true })
     // Successful import -> set correct classes and feedback to inform user
     row.addClass('import-groupname-done')
     $('#processed-indicator-' + groupname).html('<i class="fa-solid fa-check"></i>')

--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -369,12 +369,12 @@ async function processImportedRow (row) {
 
   try {
     const response = await Yoda.call('group_process_csv',
-    {
-      csv_header_and_data: importRowData,
-      allow_update: $('#import-allow-updates').is(':checked'),
-      delete_users: $('#import-delete-users').is(':checked')
-    },
-    { quiet: true, rawResult: true })
+      {
+        csv_header_and_data: importRowData,
+        allow_update: $('#import-allow-updates').is(':checked'),
+        delete_users: $('#import-delete-users').is(':checked')
+      },
+      { quiet: true, rawResult: true })
     // Successful import -> set correct classes and feedback to inform user
     row.addClass('import-groupname-done')
     $('#processed-indicator-' + groupname).html('<i class="fa-solid fa-check"></i>')
@@ -382,11 +382,11 @@ async function processImportedRow (row) {
 
     row.addClass('table-success')
     let successHtml = ''
-      response.status_info.forEach(function myFunction (item) {
-        successHtml += item + '<br/>'
+    response.status_info.forEach(function myFunction (item) {
+      successHtml += item + '<br/>'
     })
     $('#success-import-' + groupname).html(successHtml)
-    
+
     // Solely added for test automation - splinter.
     // This was the only way to be able to perform an automated click work on a row.
     // in itself this functionality is superfluous - as it is dealt with in $('.import-csv-group-ok').click(function() {}


### PR DESCRIPTION
Problem

When modifying groups with a CSV, I use groups that are already created (to add users for example) . I check the “Allow updates” button and “Process CSV”. I then get an error for existing groups even though the users have been added

Solution
When import groups using a CSV file, now the user can be informed with a simple, but useful descriptive message of the actions taken:

A message may consist of 1 or more of the following phrases:

    Group '<group_name>' created.
    Group '<group_name>' already exists.
    Users added (<no_users_added>).
    Users removed (<no_users_removed>).

**This should be merge taking into account the following PR also 
https://github.com/UtrechtUniversity/yoda-ruleset/pull/522**
