### PR TITLE
YDA-6012 bug fix for silent uploading failure

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,7 +153,7 @@ with app.app_context():
 
 # CSRF protection.
 csrf = CSRFProtect(app)
-
+app.config['WTF_CSRF_TIME_LIMIT'] = None  # Set CSRF token lifetime tied to the life of the session.
 
 @app.before_request
 def static_loader() -> Optional[Response]:

--- a/app.py
+++ b/app.py
@@ -155,6 +155,7 @@ with app.app_context():
 csrf = CSRFProtect(app)
 app.config['WTF_CSRF_TIME_LIMIT'] = None  # Set CSRF token lifetime tied to the life of the session.
 
+
 @app.before_request
 def static_loader() -> Optional[Response]:
     """


### PR DESCRIPTION
1. Set CSRF token lifetime tied to the life of the session. Tested in DGK acceptance env (1.9.4) and local dev (1.10 and 1.9.4)
2. Regarding the error loggings, csrf's error catch requires logging level of python logging module to be at INFO level (which is a more detailed level than what we currently have). We were not sure if we should increase the logging level of the whole application, since the failure is now resolved. So I didn't add loggings, but I tested the logging, and added the code snippet in https://utrechtuniversity.atlassian.net/browse/YDA-6012