### PR TITLE
YDA-6146: scroll normally when short group list

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -20,6 +20,13 @@ function collapseUncollapseOnScroll () {
   const topOfScreenPoint = 60
   const collapsePoint = 300
   const st = Math.floor(window.scrollY)
+  // Should be height of: header + search bar + whichever tree/list is visible
+  const groupsListHeight = $('#groups-card-header').outerHeight() +
+    ($('#pills-tree.show').outerHeight() || 0) +
+    ($('#pills-list.show').outerHeight() || 0) +
+    $('#search').outerHeight()
+  // group properties + group members list (+ priv buttons)
+  const groupOverviewHeight = $('#group-overview').outerHeight()
   let collapseEl = bootstrap.Collapse.getInstance('#group-properties')
   if (!collapseEl) {
     collapseEl = new bootstrap.Collapse('#group-properties', {
@@ -29,6 +36,10 @@ function collapseUncollapseOnScroll () {
 
   if (Math.abs(lastScrollTop - st) <= delta) {
     return
+  } else if (groupsListHeight < groupOverviewHeight) {
+    // Skip if group list shorter than screen
+    lastScrollTop = st
+    return
   }
 
   if (st <= lastScrollTop && st <= topOfScreenPoint) {
@@ -37,7 +48,7 @@ function collapseUncollapseOnScroll () {
   } else if (st > lastScrollTop &&
     st > collapsePoint &&
     Math.abs(lastScrollTop - st) <= collapseDelta &&
-    $('#group-overview').outerHeight() + buffer > $(window).height()) {
+    groupOverviewHeight + buffer > $(window).height()) {
     // Have scrolled down at least a little
     bootstrap.Collapse.getInstance('#group-properties').hide()
   }

--- a/group_manager/templates/group_manager/index.html
+++ b/group_manager/templates/group_manager/index.html
@@ -29,7 +29,7 @@
     <div class="col-md-6">
         <h1 id="group-manager-text">Group manager</h1>
         <div class="card groups">
-            <div class="card-header">
+            <div id="groups-card-header" class="card-header">
                 Groups
                 <ul class="nav nav-pills float-end" id="pills-tab" role="tablist">
                     <li class="nav-item" role="presentation">


### PR DESCRIPTION
In the group manager, when the group list is shorter than the group properties and group members cards, scroll normally, do not autocollapse group properties.

In my testing, the issue with being forced to the top of the screen again only appeared when the list of groups was shorter than the group properties and group members cards. This PR only fixes the issue in this case.

Passes ui group manager tests.

