### PR TITLE
YDA-6077: prevent incompatible metadata schema configuration for deposit groups

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -756,6 +756,8 @@ $(function () {
     /// The default prefix when adding a new group.
     GROUP_DEFAULT_PREFIX: 'research-',
 
+    DEPOSIT_COMPATIBLE_SCHEMAS: ['dag-0'],
+
     unloading: false, /// < Set to true when a navigation action is detected. Used for better error reporting.
 
     groupHierarchy: null, /// < A group hierarchy object. See Yoda.groupManager.load().
@@ -1552,10 +1554,15 @@ $(function () {
 
               schemas.forEach(function (schema) {
                 if (schema.startsWith(query)) {
-                  results.push({
-                    id: schema,
-                    text: schema
-                  })
+                  // If group is deposit only load compatible schemas
+                  const prefix = $('#f-group-create-name').attr('data-prefix')
+
+                  if (prefix !== "deposit-" || that.DEPOSIT_COMPATIBLE_SCHEMAS.includes(schema)){
+                    results.push({
+                      id: schema,
+                      text: schema
+                    })
+                  }
                 }
               })
 
@@ -2329,6 +2336,15 @@ $(function () {
           } else {
             $('.schema-id').hide()
           }
+        }
+
+        // If deposit group is selected then automatically switch schema to the compatible one
+        if (newPrefix === "deposit-"){
+          const defaultDepositSchema = that.DEPOSIT_COMPATIBLE_SCHEMAS[0]
+          console.log(defaultDepositSchema)
+          const depositSchemaOption = new Option(defaultDepositSchema, defaultDepositSchema, true, true)
+          $("#f-group-create-schema-id").append(depositSchemaOption).trigger('change')
+          $('#f-group-create-schema-id').val(defaultDepositSchema).trigger('change')
         }
 
         const hadRetentionPeriod = that.prefixHasExpirationDate(oldPrefix)

--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -1557,7 +1557,7 @@ $(function () {
                   // If group is deposit only load compatible schemas
                   const prefix = $('#f-group-create-name').attr('data-prefix')
 
-                  if (prefix !== "deposit-" || that.DEPOSIT_COMPATIBLE_SCHEMAS.includes(schema)){
+                  if (prefix !== 'deposit-' || that.DEPOSIT_COMPATIBLE_SCHEMAS.includes(schema)) {
                     results.push({
                       id: schema,
                       text: schema
@@ -2339,11 +2339,10 @@ $(function () {
         }
 
         // If deposit group is selected then automatically switch schema to the compatible one
-        if (newPrefix === "deposit-"){
+        if (newPrefix === 'deposit-') {
           const defaultDepositSchema = that.DEPOSIT_COMPATIBLE_SCHEMAS[0]
-          console.log(defaultDepositSchema)
           const depositSchemaOption = new Option(defaultDepositSchema, defaultDepositSchema, true, true)
-          $("#f-group-create-schema-id").append(depositSchemaOption).trigger('change')
+          $('#f-group-create-schema-id').append(depositSchemaOption).trigger('change')
           $('#f-group-create-schema-id').val(defaultDepositSchema).trigger('change')
         }
 


### PR DESCRIPTION
This fix ensures that group managers cannot select a metadata schema that is incompatible for deposit groups. Now, for deposit groups, the list of schemas is filtered by compatible schemas and the previously selected schema is reset to ensure a wrong configuration is not saved.