### PR TITLE
Group manager: fix issue when adding more than one user

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -2045,6 +2045,7 @@ $(function () {
           )
         }
       }
+      $(el).find('input[type="submit"]').removeClass('disabled').val('Add')
     },
 
     /**


### PR DESCRIPTION
This relates to an issue introduced in YDA-5956, where once one user was added, the add user button became disabled.