### PR TITLE
YDA-6336: check user's read rights before loading metadata

### DIFF
--- a/themes/uu_dag/vault/static/vault/js/vault.js
+++ b/themes/uu_dag/vault/static/vault/js/vault.js
@@ -11,7 +11,7 @@ $(document).ajaxSend(function (e, request, settings) {
 })
 
 let currentFolder
-const hasReadRights = true
+let hasReadRights = true
 
 $(function () {
   // Extract current location from query string (default to '').
@@ -48,7 +48,6 @@ $(function () {
 function browse (dir = '', changeHistory = false) {
   currentFolder = dir
   makeBreadcrumb(dir)
-  metadataInfo(dir)
   topInformation(dir, true) // only here topInformation should show its alertMessage
   buildFileBrowser(dir)
 }
@@ -352,15 +351,35 @@ window.addEventListener('popstate', function (e) {
   browse('dir' in query ? query.dir : '')
 })
 
-function topInformation (dir, showAlert) {
+function topInformation (dir) {
   if (typeof dir !== 'undefined') {
     Yoda.call('vault_collection_details',
       { path: Yoda.basePath + dir }).then((data) => {
       const vaultStatus = data.status
       const vaultActionPending = data.vault_action_pending
       const hasWriteRights = 'yes'
+      const userType = data.member_type
       const isDatamanager = data.is_datamanager
       const actions = []
+
+      if (userType !== 'none' || isDatamanager) {
+        // Datamanager, Researcher, normal, groupmanager cases
+        hasReadRights = true
+      } else {
+        // Anyone else case
+        hasReadRights = false
+      }
+
+      if (hasReadRights){
+        metadataInfo(dir)
+      } else {
+        $('.metadata-info').show()
+        $('.metadata-title').text(dir)
+        $('.metadata-description').text("N/A")
+        $('.metadata-access').text("N/A")
+        $('.metadata-data-classification').text("N/A")
+        $('.metadata-license').text("N/A")
+      }
 
       $('.btn-group button.metadata-form').hide()
       $('.top-information').hide()

--- a/themes/uu_dag/vault/static/vault/js/vault.js
+++ b/themes/uu_dag/vault/static/vault/js/vault.js
@@ -370,15 +370,15 @@ function topInformation (dir) {
         hasReadRights = false
       }
 
-      if (hasReadRights){
+      if (hasReadRights) {
         metadataInfo(dir)
       } else {
         $('.metadata-info').show()
         $('.metadata-title').text(dir)
-        $('.metadata-description').text("N/A")
-        $('.metadata-access').text("N/A")
-        $('.metadata-data-classification').text("N/A")
-        $('.metadata-license').text("N/A")
+        $('.metadata-description').text('N/A')
+        $('.metadata-access').text('N/A')
+        $('.metadata-data-classification').text('N/A')
+        $('.metadata-license').text('N/A')
       }
 
       $('.btn-group button.metadata-form').hide()

--- a/themes/uu_dag/vault/static/vault/js/vault.js
+++ b/themes/uu_dag/vault/static/vault/js/vault.js
@@ -426,7 +426,7 @@ function metadataInfo (dir) {
       { coll: Yoda.basePath + dir },
       { rawResult: true })
       .then((result) => {
-        if (!result || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
+        if (!result || !result.data || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
 
         const metadata = result.data.metadata
         $('.metadata-info').show()

--- a/vault/static/vault/js/datapackage.js
+++ b/vault/static/vault/js/datapackage.js
@@ -181,7 +181,6 @@ $(function () {
     }, 10)
   })
 
-  // TODO: add user check here before handling metadata?
   metadataInfo(currentFolder)
 })
 

--- a/vault/static/vault/js/datapackage.js
+++ b/vault/static/vault/js/datapackage.js
@@ -15,6 +15,7 @@ let group
 let bounds = [[1, 1], [1, 1]]
 let mymap = null
 let maplayer = null
+let hasReadRights = true
 
 let metadata // Make it global so functions on different levels can access it without having to pass it as a parameter entirely
 // mfunction contains specific presentation functions that are initiated from the template on the base of dpAttr (datapackage attribute)
@@ -180,13 +181,43 @@ $(function () {
     }, 10)
   })
 
-  if (dpIsRestricted) {
-    handleRestrictedMetadataInfo()
-  } else {
-    // First collect the information, then present it
-    handleOpenMetadataInfo(currentFolder)
-  }
+  // TODO: add user check here before handling metadata?
+  metadataInfo(currentFolder)
 })
+
+
+function metadataInfo (dir) {
+  if (typeof dir !== 'undefined') {
+    Yoda.call('vault_collection_details',
+      { path: Yoda.basePath + dir },
+      { quiet: true, rawResult: true }).then((dataRaw) => {
+      const data = dataRaw.data
+      const userType = data.member_type
+      const isDatamanager = data.is_datamanager
+
+      if (userType !== 'none' || isDatamanager) {
+        // Datamanager, Researcher, normal, groupmanager cases
+        hasReadRights = true
+      } else {
+        // Anyone else case
+        hasReadRights = false
+      }
+
+      if (dpIsRestricted) {
+        handleRestrictedMetadataInfo()
+      } else {
+        if (hasReadRights){ 
+          // First collect the information, then present it
+          handleOpenMetadataInfo(currentFolder)
+        } else {
+          $('.metadata-title').text(currentFolder)
+        }
+      }
+    })
+  } else {
+    handleRestrictedMetadataInfo()
+  }
+}
 
 async function handleRestrictedMetadataInfo () {
   /* Collect and present restricted datapackage metadata through the search api based upon a uuid of 1 single datapackage. */

--- a/vault/static/vault/js/datapackage.js
+++ b/vault/static/vault/js/datapackage.js
@@ -246,7 +246,7 @@ function handleOpenMetadataInfo (dir) {
       { coll: Yoda.basePath + dir },
       { rawResult: true })
       .then((result) => {
-        if (!result || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
+        if (!result || !result.data || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
 
         metadata = result.data.metadata
         // bring separately delivered deposit_date into the metadata dict for ease of reference

--- a/vault/static/vault/js/datapackage.js
+++ b/vault/static/vault/js/datapackage.js
@@ -185,7 +185,6 @@ $(function () {
   metadataInfo(currentFolder)
 })
 
-
 function metadataInfo (dir) {
   if (typeof dir !== 'undefined') {
     Yoda.call('vault_collection_details',
@@ -206,7 +205,7 @@ function metadataInfo (dir) {
       if (dpIsRestricted) {
         handleRestrictedMetadataInfo()
       } else {
-        if (hasReadRights){ 
+        if (hasReadRights) {
           // First collect the information, then present it
           handleOpenMetadataInfo(currentFolder)
         } else {

--- a/vault/static/vault/js/vault.js
+++ b/vault/static/vault/js/vault.js
@@ -711,7 +711,7 @@ window.addEventListener('popstate', function (e) {
   browse('dir' in query ? query.dir : '')
 })
 
-function topInformation (dir, showAlert, rebuildFileBrowser = false) {
+function topInformation (dir, rebuildFileBrowser = false) {
   if (typeof dir !== 'undefined') {
     Yoda.call('vault_collection_details',
       { path: Yoda.basePath + dir },
@@ -847,7 +847,16 @@ function topInformation (dir, showAlert, rebuildFileBrowser = false) {
         if (vaultStatus === '' || vaultStatus === 'INCOMPLETE') {
           $('.alert.is-processing').show()
         } else {
-          metadataInfo(dir)
+          if (hasReadRights){
+            metadataInfo(dir)
+          } else {
+            $('.metadata-info').show()
+            $('.metadata-title').text(dir)
+            $('.metadata-description').text("N/A")
+            $('.metadata-access').text("N/A")
+            $('.metadata-data-classification').text("N/A")
+            $('.metadata-license').text("N/A")
+          }
           if (vaultStatus === 'PUBLISHED' || vaultStatus === 'PENDING_DEPUBLICATION' || vaultStatus === 'PENDING_REPUBLICATION' || vaultStatus === 'DEPUBLISHED') {
             $('.metadata-form-size').addClass('col-lg-8')
             $('.meta-title-size').removeClass('col-lg-2').addClass('col-lg-3')

--- a/vault/static/vault/js/vault.js
+++ b/vault/static/vault/js/vault.js
@@ -1129,7 +1129,7 @@ function metadataInfo (dir) {
       { coll: Yoda.basePath + dir },
       { quiet: true, rawResult: true })
       .then((result) => {
-        if (!result || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
+        if (!result || !result.data || Object.keys(result.data).length === 0) { return console.info('No result data from meta_form_load') }
 
         const metadata = result.data.metadata
         $('.metadata-info').show()

--- a/vault/static/vault/js/vault.js
+++ b/vault/static/vault/js/vault.js
@@ -847,15 +847,15 @@ function topInformation (dir, rebuildFileBrowser = false) {
         if (vaultStatus === '' || vaultStatus === 'INCOMPLETE') {
           $('.alert.is-processing').show()
         } else {
-          if (hasReadRights){
+          if (hasReadRights) {
             metadataInfo(dir)
           } else {
             $('.metadata-info').show()
             $('.metadata-title').text(dir)
-            $('.metadata-description').text("N/A")
-            $('.metadata-access').text("N/A")
-            $('.metadata-data-classification').text("N/A")
-            $('.metadata-license').text("N/A")
+            $('.metadata-description').text('N/A')
+            $('.metadata-access').text('N/A')
+            $('.metadata-data-classification').text('N/A')
+            $('.metadata-license').text('N/A')
           }
           if (vaultStatus === 'PUBLISHED' || vaultStatus === 'PENDING_DEPUBLICATION' || vaultStatus === 'PENDING_REPUBLICATION' || vaultStatus === 'DEPUBLISHED') {
             $('.metadata-form-size').addClass('col-lg-8')


### PR DESCRIPTION
This additional check fixes an error caused by not having read rights on metadata files, mostly specific to users who have permission to see folder structure but not file contents (e.g., technical admins).