### PR TITLE
Yda 6103 reset csv instructions after reopen group imports

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -648,12 +648,12 @@ $(function () {
     $('#dlg-import-groups-csv').modal('show')
   })
 
-  $('#dlg-import-groups-csv').on('hidden.bs.modal', function() {
+  $('#dlg-import-groups-csv').on('hidden.bs.modal', function () {
     // Safeguard: Store initial instructions if undefined (do this once at page load)
     if (typeof initialImportCsvHtml === 'undefined') {
-        initialImportCsvHtml = $('#result-import-groups-csv').html()
+      initialImportCsvHtml = $('#result-import-groups-csv').html()
     }
-    
+
     // Restore initial state
     $('#result-import-groups-csv').html(initialImportCsvHtml)
     // Hide the process CSV button

--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -594,6 +594,9 @@ async function removeUserFromGroup (row, groupName) {
 }
 
 $(function () {
+  // Store the initial state of the CSV import instructions
+  let initialImportCsvHtml = $('#result-import-groups-csv').html()
+
   // Multiple user role change
   $('.users.card .update-button').on('click', function (e) {
     const newRole = $(this).attr('data-target-role')
@@ -643,6 +646,20 @@ $(function () {
 
   $('.import-groups-csv').on('click', function () {
     $('#dlg-import-groups-csv').modal('show')
+  })
+
+  $('#dlg-import-groups-csv').on('hidden.bs.modal', function() {
+    // Safeguard: Store initial instructions if undefined (do this once at page load)
+    if (typeof initialImportCsvHtml === 'undefined') {
+        initialImportCsvHtml = $('#result-import-groups-csv').html()
+    }
+    
+    // Restore initial state
+    $('#result-import-groups-csv').html(initialImportCsvHtml)
+    // Hide the process CSV button
+    $('.div-process-results-import').addClass('hidden')
+    $('.process-csv').prop('disabled', true)
+    $('#file-input').val('') // Clear file input
   })
 
   $('.process-csv').on('click', function () {


### PR DESCRIPTION
**Solution logic:** 
Reset to the instruction page after the Import Groups modal is closed / hidden
**Expected behaviour:** 
Regardless a success or failed upload of csv import, click the import CSV button will always display the instructions. 