### PR TITLE
YDA-6501: wait until whole page has loaded in fileviewer

### DIFF
--- a/fileviewer/static/fileviewer/js/file-display.js
+++ b/fileviewer/static/fileviewer/js/file-display.js
@@ -51,7 +51,7 @@ async function getTextObj (currentFileExtension) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+window.addEventListener('load', function () {
   document.getElementById('file-output').style.display = 'none'
 
   // Extract current location from query string (default to '').


### PR DESCRIPTION
In Chrome based browsers DOMContentLoaded is sometimes too fast.