### PR TITLE
YDA-6515: make group_delete error alert more informative

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -1984,7 +1984,11 @@ $(function () {
         // Re-enable group list entry.
         $('#group-list .group.delete-pending[data-name="' + Yoda.escapeQuotes(groupName) + '"]').removeClass('delete-pending disabled').attr('title', '')
 
-        if ('message' in result) { window.alert(result.message) } else {
+        if ('message' in result) {
+          window.alert(result.message)
+        } else if ('status_info' in result) {
+          window.alert(result.status_info)
+        } else {
           window.alert(
             'Error: Could not remove the selected group due to an internal error.\n' +
                                 'Please contact a Yoda administrator'


### PR DESCRIPTION
This PR adds more error information to the pop-up that appears when an attempt at removing a group fails.