### PR TITLE
YDA-6534: update iCommands docs link

### DIFF
--- a/user/templates/user/data_transfer.html
+++ b/user/templates/user/data_transfer.html
@@ -51,7 +51,7 @@
             <i aria-hidden="true" class="fa-solid fa-terminal"></i> This is a command line tool, operated in a terminal
           </div>
           <p>
-            Yoda is based on iRODS technology. The <a href="https://docs.irods.org/4.2.12/icommands/user/" target="_blank">iCommands</a> allows you to interact with the iRODS backend of Yoda directly.
+            Yoda is based on iRODS technology. The <a href="https://docs.irods.org/4.3.4/icommands/user/" target="_blank">iCommands</a> allows you to interact with the iRODS backend of Yoda directly.
             Therefore, it is possible to transfer data to and from Yoda using the iRODS communication protocol.
             The iCommands are only available for Linux, for other operating systems we recommend the GoCommands.
             You need to configure the iCommands to connect to this Yoda environment.


### PR DESCRIPTION
Update link to iCommands documentation on data transfer page, so that it links to the iCommands version that matches the iRODS server version.