### PR TITLE
YDA-6550: disable demoting yourself as group manager to viewer

### DIFF
--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -1302,12 +1302,21 @@ $(function () {
       // inform users of member count and selection count
       this.updateGroupMemberCount($('#group-list .active.group').attr('data-name'))
 
-      const countSelected = $('#user-list .active').length
+      const $usersSelected = $('#user-list .active')
+      const usersSelected = document.querySelectorAll('#user-list .active')
+      const countSelected = $usersSelected.length
       const $userPanel = $('.card.users')
       if (this.canManageGroup($('#group-list .active.group').attr('data-name'))) {
         if (countSelected > 0) {
           $userPanel.find('.delete-button').removeClass('disabled')
           $userPanel.find('.update-button').removeClass('disabled')
+
+          // Disable demoting current user to viewer if current user is a group manager,
+          // it needs to be two step process
+          const viewerButton = document.querySelector(".update-button[data-target-role='reader']")
+          if (usersSelected != null && viewerButton != null && Array.prototype.some.call(usersSelected, (item) => this.userNameFull === item.getAttribute('data-name'))) {
+            viewerButton.classList.add('disabled')
+          }
           return
         }
       }
@@ -1322,8 +1331,13 @@ $(function () {
     deselectUser: function () {
       const $userPanel = $('.card.users')
       const $userList = $('#user-list')
+      const viewerButton = document.querySelector("update-button[data-target-role='reader']")
       $userList.find('.active').removeClass('active')
       $userPanel.find('.update-button, .delete-button').addClass('disabled')
+      // Re-enable the viewer button
+      if (viewerButton != null) {
+        viewerButton.classList.remove('disabled')
+      }
     },
 
     /**

--- a/group_manager/static/group_manager/js/group_manager.js
+++ b/group_manager/static/group_manager/js/group_manager.js
@@ -1331,7 +1331,7 @@ $(function () {
     deselectUser: function () {
       const $userPanel = $('.card.users')
       const $userList = $('#user-list')
-      const viewerButton = document.querySelector("update-button[data-target-role='reader']")
+      const viewerButton = document.querySelector(".update-button[data-target-role='reader']")
       $userList.find('.active').removeClass('active')
       $userPanel.find('.update-button, .delete-button').addClass('disabled')
       // Re-enable the viewer button


### PR DESCRIPTION
Current policies demote user in two steps. This causes internal error for demoting yourself as a group manager. This is a workaround to prevent the user from doing this.

I tried to use less jquery-dependent way.

Relates to https://github.com/UtrechtUniversity/yoda/pull/612