### PR TITLE
YDA-6205 pregenerate statistics export

### DIFF
--- a/cache_config.py
+++ b/cache_config.py
@@ -38,7 +38,7 @@ API_CACHE_TIMEOUTS = {
     "notifications_load":                              {"prepopulate": True,  "timeout": 120},
     "resource_browse_group_data":                      {"prepopulate": True,  "timeout": 3600},
     "resource_category_stats":                         {"prepopulate": True,  "timeout": 3600},
-    "resource_monthly_category_stats":                 {"prepopulate": True,  "timeout": 3600},
+    "resource_monthly_category_stats":                 {"prepopulate": False, "timeout": 120},
     "resource_full_year_differentiated_group_storage": {"prepopulate": False, "timeout": 3600},
     "schema_get_schemas":                              {"prepopulate": True,  "timeout": 3600},
     "settings_load":                                   {"prepopulate": True,  "timeout": 3600},


### PR DESCRIPTION
Pregenerate the export data of the statistics module in the Yoda ruleset. This commit effectively disables caching of statistics export data. The data is now normally pregenerated at the ruleset level, so caching at the portal level is not needed anymore.