### PR TITLE
YDA-5954: fix protal doesnot show upload queue with additional uploads

### DIFF
--- a/deposit/static/deposit/js/data.js
+++ b/deposit/static/deposit/js/data.js
@@ -249,11 +249,23 @@ $(function () {
   // Flow.js handle events
   r.on('filesAdded', function (files) {
     if (files.length) {
-      $('#files').html('')
-      // clear information present for new totals
-      $('.uploads-progress-information').html('')
-      $('.uploads-total-progress-bar').css('width', '0%')
-      $('.uploads-total-progress-bar-perc').html('0%')
+      const newFileIds = files.map(file => file.uniqueIdentifier)
+
+      // Check if there is at least one older file, and its upload is not complete.
+      const hasExistingIncompleteUploads = r.files.some(flowFile => {
+        return !newFileIds.includes(flowFile.uniqueIdentifier) &&
+          $('#' + flowFile.uniqueIdentifier).length &&
+          flowFile.progress() < 1
+      })
+
+      // Reset UI only not incomplete uploads
+      if (!hasExistingIncompleteUploads) {
+        $('#files').html('')
+        // clear information present for new totals
+        $('.uploads-progress-information').html('')
+        $('.uploads-total-progress-bar').css('width', '0%')
+        $('.uploads-total-progress-bar-perc').html('0%')
+      }
 
       const sortedFiles = files.sort((a, b) => a.name.localeCompare(b.name))
 
@@ -332,6 +344,8 @@ $(function () {
       })
     }
     $('#uploads').removeClass('hidden')
+    // Refresh progress display
+    updateProgress(r.files)
   })
   r.on('filesSubmitted', function () {
     const path = $('.upload').attr('data-path')

--- a/research/static/research/js/research.js
+++ b/research/static/research/js/research.js
@@ -342,11 +342,23 @@ $(function () {
   // Flow.js handle events
   r.on('filesAdded', function (files) {
     if (files.length) {
-      $('#files').html('')
-      // clear information present for new totals
-      $('.uploads-progress-information').html('')
-      $('.uploads-total-progress-bar').css('width', '0%')
-      $('.uploads-total-progress-bar-perc').html('0%')
+      const newFileIds = files.map(file => file.uniqueIdentifier)
+
+      // Check if there is at least one older file, and its upload is not complete.
+      const hasExistingIncompleteUploads = r.files.some(flowFile => {
+        return !newFileIds.includes(flowFile.uniqueIdentifier) &&
+          $('#' + flowFile.uniqueIdentifier).length &&
+          flowFile.progress() < 1
+      })
+
+      // Reset UI only not incomplete uploads
+      if (!hasExistingIncompleteUploads) {
+        $('#files').html('')
+        // clear information present for new totals
+        $('.uploads-progress-information').html('')
+        $('.uploads-total-progress-bar').css('width', '0%')
+        $('.uploads-total-progress-bar-perc').html('0%')
+      }
 
       const sortedFiles = files.sort((a, b) => a.name.localeCompare(b.name))
 
@@ -425,6 +437,8 @@ $(function () {
       })
     }
     $('#uploads').removeClass('hidden')
+    // Refresh progress display
+    updateProgress(r.files)
   })
   r.on('filesSubmitted', function () {
     const path = $('.upload').attr('data-path')


### PR DESCRIPTION
Rootcause: When an additional upload is added while the previous upload is still incomplete, the filsAdded handler clears the upload UI before adding new rows of the newly added files. In addition, the aggregate progress calculation only considers uploading files that still have a row in the DOM, hence, earlier uploads disappear from the progress bars although they are still being uploaded. 

The fix keeps existing row if there are unfinished uploads already in queued or running, and only resets the upload UI pane when starting a fresh upload (when earlier uploads are complete).