### PR TITLE
Update user notifications default setting

### DIFF
--- a/user/user.py
+++ b/user/user.py
@@ -182,7 +182,7 @@ def settings() -> Response:
     if request.method == 'POST':
         # Build user settings dict.
         settings = {}
-        settings['mail_notifications'] = request.form.get('mail_notifications', "OFF")
+        settings['mail_notifications'] = request.form.get('mail_notifications', "IMMEDIATE")
         settings['group_manager_view'] = request.form.get('group_manager_view', "TREE")
         settings['number_of_items'] = request.form.get('number_of_items', "10")
         settings['color_mode'] = request.form.get('color_mode', "AUTO")


### PR DESCRIPTION
Set user notification setting to IMMEDIATE by default. This change is based on feedback from users that it's easy to miss notifications if they don't receive an email about them. We want to provide a default setting that avoids that issue.