### PR TITLE
YDA-7119: optimize API call handling

### DIFF
--- a/api.py
+++ b/api.py
@@ -5,16 +5,17 @@ __license__   = 'GPLv3, see LICENSE'
 
 import base64
 import hashlib
-import json
 import re
 import sys
 import zlib
 from timeit import default_timer as timer
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
+import orjson
 from flask import Blueprint, g, jsonify, request, Response
 from flask import current_app as app
 from irods import message, rule
+from typing_extensions import TypeGuard
 
 from cache_config import cache, clear_api_cache_keys, get_api_cache_timeout, make_key
 from errors import InvalidAPIError, UnauthorizedAPIAccessError
@@ -40,9 +41,12 @@ def _call(fn: str) -> Response:
     if not re.match(r"^[a-z_]+$", fn):
         raise InvalidAPIError
 
-    data = json.loads(request.form.get('data', '{}'))
-    result = call(fn, data)
-    return jsonify(result), get_response_code(result)
+    parameters = orjson.loads(request.form.get('data', '{}'))
+    parsed_result, unparsed_result = _internal_call(fn, parameters)
+    status_code = get_response_code(parsed_result)
+    return Response(response=unparsed_result,
+                    status=status_code,
+                    mimetype="application/json")
 
 
 def get_response_code(result: Dict[str, Any]) -> int:
@@ -65,6 +69,20 @@ def call(fn: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 
     :returns: The result of the API call as a dictionary
     """
+    return _internal_call(fn, data)[0]
+
+
+def _internal_call(fn: str, data: Optional[Dict[str, Any]] = None) -> Tuple[Dict[str, Any], bytes]:
+    """Call the specified API function with the provided data.
+
+    :param fn:   The name of the API function to call
+    :param data: Optional dictionary of data to pass to the function
+
+    :returns: The result of the API call as a tuple of a dictionary (the parsed result) and
+              bytes (the unparsed result)
+
+    :raises TypeError: if the API response does not have the expected type
+    """
     caching_enabled = app.config.get('CACHING_ENABLED', False)
     log_api_duration = app.config.get('LOG_API_CALL_DURATION', False)
 
@@ -75,8 +93,8 @@ def call(fn: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     data = data or {}
 
     # Prepare parameters.
-    params = json.dumps(data)
-    encoded_params = hashlib.shake_256(params.encode('utf-8')).hexdigest(20)
+    params = orjson.dumps(data)
+    encoded_params = hashlib.shake_256(params).hexdigest(20)
 
     cached_result = None
     if caching_enabled:
@@ -100,15 +118,26 @@ def call(fn: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if log_api_duration:
         end_time = timer()
         call_duration = round((end_time - start_time) * 1000)
-        log_message = f"DEBUG: {call_duration:4d}ms api_{fn} {params}"
+        log_message = f"DEBUG: {call_duration:4d}ms api_{fn} {params.decode('utf-8')}"
         if cached_result is not None:
             log_message += " (from cache)"
         print(log_message, file=sys.stderr)
 
-    return json.loads(result)
+    response = (orjson.loads(result), result)
+    if _verify_api_response_type(response):
+        return response
+    else:
+        raise TypeError("Unexpected response type for API call.")
 
 
-def execute_rule(fn: str, params: str) -> str:
+def _verify_api_response_type(response: Any) -> TypeGuard[Tuple[Dict[str, Any], bytes]]:
+    return (isinstance(response, tuple)
+            and isinstance(response[1], bytes)
+            and isinstance(response[0], dict)
+            and all(isinstance(k, str) for k in response[0]))
+
+
+def execute_rule(fn: str, params: bytes) -> str:
     """Execute the specified iRODS rule with the given parameters.
 
     :param fn:     The name of the API function to execute
@@ -142,7 +171,7 @@ def execute_rule(fn: str, params: str) -> str:
         return '++\n'.join(f'"{escape_quotes(s[i * m:i * m + m])}"' for i in range(break_strings(len(s), m) + 1))
 
     # Compress params and encode as base64 to reduce size (max rule length in iRODS is 20KB)
-    compressed_params = zlib.compress(params.encode())
+    compressed_params = zlib.compress(params)
     base64_encoded_params = base64.b64encode(compressed_params)
     arg_str_expr = nrep_string_expr(base64_encoded_params.decode('utf-8'))
 

--- a/cache_config.py
+++ b/cache_config.py
@@ -4,11 +4,11 @@ __copyright__ = 'Copyright (c) 2024-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import hashlib
-import json
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from typing import Any, Callable, List, Optional
 
+import orjson
 from flask import current_app as app, g, request, session
 from flask_caching import Cache
 
@@ -201,8 +201,8 @@ def populate_api_cache(fn: str, user: str, irods: str, session_id: str) -> None:
         if fn in API_CACHE_PARAMS:
             data = API_CACHE_PARAMS[fn]["default_params"]
 
-        params = json.dumps(data)
-        encoded_params = hashlib.shake_256(params.encode("utf-8")).hexdigest(20)
+        params = orjson.dumps(data)
+        encoded_params = hashlib.shake_256(params).hexdigest(20)
         cache_key = make_key(f"{fn}:{encoded_params}")
         if cache.get(cache_key) is None:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ python-magic==0.4.27
 Werkzeug==3.1.4
 psutil==6.1.1
 humanize==4.11.0
+orjson==3.11.9
+typing_extensions==4.16.0


### PR DESCRIPTION
This optimizes the code for handling API calls
by switching to a high-performance json library (orjson), It also reduces the number of JSON dump/parse cycles, by just passing the original ruleset response instead of dumping the parsed response.