### PR TITLE
YDA-7193: fix DR module overview

### DIFF
--- a/datarequest/templates/datarequest/index.html
+++ b/datarequest/templates/datarequest/index.html
@@ -10,8 +10,8 @@
 {% block scripts %}
 <script src="{{ url_for('static', filename='lib/jquery-3.7.1/jquery-3.7.1.min.js') }}"></script>
 <script> window.config = {
-  archived: '{{ archived }}',
-  dacrequests: '{{ dacrequests }}'
+  archived: {{ archived | tojson }},
+  dacrequests: {{ dacrequests | tojson }}
 }
 </script>
 <script src="{{ url_for('static', filename='lib/datatables-1.13.5/datatables.min.js') }}"></script>


### PR DESCRIPTION
The data request module overview wasn't working
correctly after introduction of type checking,
because the portal was passing API parameters
as strings rather than booleans.