### PR TITLE
Data request module: add missing status

### DIFF
--- a/datarequest/datarequest.py
+++ b/datarequest/datarequest.py
@@ -47,6 +47,7 @@ def permission_check(request_id: str, roles: List[str], statuses: Optional[List[
 
 
 class human_readable_status(Enum):
+    IN_SUBMISSION = 'In submission'
     DRAFT = 'In draft'
     PENDING_ATTACHMENTS = 'Pending attachments'
     DAO_SUBMITTED = 'Submitted (data assessment)'


### PR DESCRIPTION
Add human readable text for missing data request
module status, so that this status is shown correctly if it ever ends up in an overview.