### PR TITLE
Search: parse search limit value for API call to int

### DIFF
--- a/search/static/search/js/search.js
+++ b/search/static/search/js/search.js
@@ -82,7 +82,7 @@ const getSearchResults = (() => {
       search_string: currentSearchString,
       search_type: currentSearchType,
       offset: args.start,
-      limit: $("select[name='search_length']").val(),
+      limit: parseInt($("select[name='search_length']").val()),
       sort_order: args.order[0].dir,
       sort_on: ['name', 'modified'][args.order[0].column]
     })


### PR DESCRIPTION
This PR fixes one of the arguments for the search API call which was failing as the expected type (int) was different than the received one (string).